### PR TITLE
Update for NetworkX 3.X

### DIFF
--- a/FRAKE/FRAKE.py
+++ b/FRAKE/FRAKE.py
@@ -293,7 +293,7 @@ class KeywordExtractor :
         elif cnt == 'sh':
             cntV = list(nx.constraint(G).values())
         elif cnt == 'pr':
-            cntV = list(nx.pagerank_numpy(G).values())
+            cntV = list(nx.pagerank(G).values())
         elif cnt == 'bw':
             cntV = list(nx.betweenness_centrality(G).values())
         elif cnt == 'cl':


### PR DESCRIPTION
NetworkX >= 3 doesn't have `pagerank_numpy` anymore, see [migration notes](https://networkx.org/documentation/stable/release/migration_guide_from_2.x_to_3.0.html#switch-to-numpy-scipy-implementations-by-default-for-some-algorithms).

But the results don't seem to change if calling `pagerank`.